### PR TITLE
Add xUnit test project

### DIFF
--- a/InMemoryVectorStore.Tests/DocumentParserFactoryTests.cs
+++ b/InMemoryVectorStore.Tests/DocumentParserFactoryTests.cs
@@ -1,0 +1,21 @@
+using InMemoryVectorStore.DocumentParsers;
+using Xunit;
+
+namespace InMemoryVectorStore.Tests
+{
+    public class DocumentParserFactoryTests
+    {
+        [Theory]
+        [InlineData("test.txt", typeof(PlaintextParser))]
+        [InlineData("test.json", typeof(JsonParser))]
+        [InlineData("test.pdf", typeof(PDFParser))]
+        [InlineData("test.doc", typeof(WordParser))]
+        [InlineData("test.docx", typeof(WordParser))]
+        [InlineData("test.unknown", typeof(PlaintextParser))]
+        public void GetParser_ReturnsExpectedParserType(string fileName, Type expectedType)
+        {
+            var parser = DocumentParserFactory.GetParser(fileName);
+            Assert.IsType(expectedType, parser);
+        }
+    }
+}

--- a/InMemoryVectorStore.Tests/HighlighterTests.cs
+++ b/InMemoryVectorStore.Tests/HighlighterTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace InMemoryVectorStore.Tests
+{
+    public class HighlighterTests
+    {
+        [Fact]
+        public void HighlightMatches_HighlightsKeywords()
+        {
+            string query = "quick brown fox";
+            string content = "The quick brown fox jumps over the lazy dog.";
+
+            string highlighted = Highlighter.HighlightMatches(query, content);
+
+            Assert.Contains("\x1b[1;33mquick\x1b[0m", highlighted);
+            Assert.Contains("\x1b[1;33mbrown\x1b[0m", highlighted);
+            Assert.Contains("\x1b[1;33mfox\x1b[0m", highlighted);
+        }
+    }
+}

--- a/InMemoryVectorStore.Tests/InMemoryVectorDBTests.cs
+++ b/InMemoryVectorStore.Tests/InMemoryVectorDBTests.cs
@@ -1,0 +1,22 @@
+using InMemoryVectorStore.VectorStores;
+using Xunit;
+
+namespace InMemoryVectorStore.Tests
+{
+    public class InMemoryVectorDBTests
+    {
+        [Fact]
+        public void GenerateCacheIdentifierFromFiles_ReturnsSameHash_ForSameFiles()
+        {
+            using var tempDir = new TempDirectory();
+            var file1 = tempDir.CreateFile("a.txt", "hello");
+            var file2 = tempDir.CreateFile("b.txt", "world");
+
+            var hash1 = InMemoryVectorDB.GenerateCacheIdentifierFromFiles(new[] { file1, file2 });
+            var hash2 = InMemoryVectorDB.GenerateCacheIdentifierFromFiles(new[] { file2, file1 });
+
+            Assert.Equal(hash1, hash2);
+        }
+    }
+
+}

--- a/InMemoryVectorStore.Tests/InMemoryVectorStore.Tests.csproj
+++ b/InMemoryVectorStore.Tests/InMemoryVectorStore.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InMemoryVectorStore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/InMemoryVectorStore.Tests/ProgramTests.cs
+++ b/InMemoryVectorStore.Tests/ProgramTests.cs
@@ -1,0 +1,47 @@
+using InMemoryVectorStore.Models.VectorStores;
+using InMemoryVectorStore.ServiceWrappers;
+using InMemoryVectorStore.VectorStores;
+using Moq;
+using Xunit;
+
+namespace InMemoryVectorStore.Tests
+{
+    public class ProgramTests
+    {
+        [Fact]
+        public async Task TrainMode_CallsBuildDocumentIndexWithParsedDocuments()
+        {
+            using var tempDir = new TempDirectory();
+            var file1 = tempDir.CreateFile("doc1.txt", "Hello world");
+
+            var vectorDbMock = new Mock<IVectorDB>();
+            vectorDbMock.Setup(v => v.InitializeAsync(It.IsAny<VectorDBOptions>())).ReturnsAsync(true);
+            DocumentsAddResult result = new() { Success = true };
+            IEnumerable<DocumentToProcess>? capturedDocs = null;
+            vectorDbMock
+                .Setup(v => v.BuildDocumentIndex(It.IsAny<IEnumerable<DocumentToProcess>>(), It.IsAny<ChunkingOptions>(), "mydb"))
+                .Callback<IEnumerable<DocumentToProcess>, ChunkingOptions, string>((docs, opts, name) => capturedDocs = docs)
+                .ReturnsAsync(result);
+
+            await Program.TrainMode(vectorDbMock.Object, tempDir.Path, "mydb");
+
+            vectorDbMock.Verify(v => v.InitializeAsync(It.IsAny<VectorDBOptions>()), Times.Once);
+            vectorDbMock.Verify(v => v.BuildDocumentIndex(It.IsAny<IEnumerable<DocumentToProcess>>(), It.IsAny<ChunkingOptions>(), "mydb"), Times.Once);
+            Assert.NotNull(capturedDocs);
+            var doc = Assert.Single(capturedDocs!);
+            Assert.Equal("doc1.txt", doc.FileName);
+            Assert.Equal("Hello world", doc.Content.Trim());
+        }
+
+        [Fact]
+        public async Task ListDatabasesMode_CallsListDatabases()
+        {
+            var vectorDbMock = new Mock<IVectorDB>();
+            vectorDbMock.Setup(v => v.ListDatabasesAsync()).ReturnsAsync(new List<VectorDBInfo>());
+
+            await Program.ListDatabasesMode(vectorDbMock.Object);
+
+            vectorDbMock.Verify(v => v.ListDatabasesAsync(), Times.Once);
+        }
+    }
+}

--- a/InMemoryVectorStore.Tests/TestHelpers.cs
+++ b/InMemoryVectorStore.Tests/TestHelpers.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace InMemoryVectorStore.Tests
+{
+    internal sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; }
+
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+            System.IO.Directory.CreateDirectory(Path);
+        }
+
+        public string CreateFile(string name, string contents)
+        {
+            var full = System.IO.Path.Combine(Path, name);
+            System.IO.File.WriteAllText(full, contents);
+            return full;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Path, true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/InMemoryVectorStore.sln
+++ b/InMemoryVectorStore.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.8.34601.278
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InMemoryVectorStore", "InMemoryVectorStore.csproj", "{9CEB35E2-936A-46E5-B684-C5E519E0DD75}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InMemoryVectorStore.Tests", "InMemoryVectorStore.Tests\InMemoryVectorStore.Tests.csproj", "{59824157-6787-43EA-BBAA-189804884500}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{9CEB35E2-936A-46E5-B684-C5E519E0DD75}.Release|Any CPU.Build.0 = Release|Any CPU
+{59824157-6787-43EA-BBAA-189804884500}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{59824157-6787-43EA-BBAA-189804884500}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{59824157-6787-43EA-BBAA-189804884500}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{59824157-6787-43EA-BBAA-189804884500}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add an xUnit test project using Moq
- cover document parser factory and highlighter
- unit test the cache id helper and Program modes

## Testing
- `dotnet test InMemoryVectorStore.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495e12add083279748ff80fb466f61